### PR TITLE
Lazy loading of collection trees for better performance

### DIFF
--- a/transformer/static/js/custom.js
+++ b/transformer/static/js/custom.js
@@ -1,0 +1,8 @@
+$(document).on('click', '.collapse-icon', function(){
+  var target = $(this).attr('href')
+  $.ajax({
+      url: $(target).data('src')})
+    .done(function(data) {
+      $(target).append(data)
+    });
+});

--- a/viewer/templates/viewer/base.html
+++ b/viewer/templates/viewer/base.html
@@ -54,6 +54,7 @@
       <script src="{% static "dist/jquery/jquery-3.3.1.min.js" %}"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
       <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+      <script src="{% static "js/custom.js" %}"></script>
     {% endblock %}
 
   </body>

--- a/viewer/templates/viewer/collection-tree.html
+++ b/viewer/templates/viewer/collection-tree.html
@@ -1,0 +1,3 @@
+{% for item in object.children %}
+  {% include 'viewer/common/tree-item.html' with h=object.ancestors|length|add:"2" %}
+{% endfor %}

--- a/viewer/templates/viewer/common/tree-item.html
+++ b/viewer/templates/viewer/common/tree-item.html
@@ -1,17 +1,13 @@
 <div class="col-12">
   {% if item.has_children %}
     <h{{h}}>
-      <a class="collapse-icon {% if item.children.0.has_children %}show{% else %}collapsed{% endif %}" href="#children-{{item.pk}}" data-toggle="collapse" aria-expanded="{% if item.children.0.has_children %}true{%else%}false{% endif %}" aria-controls="children-{{item.pk}}"></a>
+      <a class="collapse-icon collapsed" href="#children-{{item.pk}}" data-toggle="collapse" aria-expanded="false" aria-controls="children-{{item.pk}}"></a>
       <a href="{% url 'app:collection-detail' item.pk %}">{{item.title}}</a>
     </h{{h}}>
   {% else %}
     <a href="{% url 'app:object-detail' item.pk %}">{{item.title}}</a>
   {% endif %}
   {% if item.has_children %}
-    <div id="children-{{item.pk}}" class="col-12 list-unstyled collapse {% if item.children.0.has_children %}show{% else %}collapsed{% endif %}">
-    {% for item in item.children %}
-      {% include 'viewer/common/tree-item.html' with h=h|add:"1" %}
-    {% endfor %}
-    </div>
+    <div id="children-{{item.pk}}" class="col-12 collapse collapsed test" data-src="{% url 'app:collection-tree' item.pk %}"></div>
   {% endif %}
 </div>

--- a/viewer/urls.py
+++ b/viewer/urls.py
@@ -4,6 +4,7 @@ from .views import *
 app_name = 'app'
 urlpatterns = [
     path('collections/', CollectionListView.as_view(), name='collection-list'),
+    re_path('collections/(?P<pk>\d+)/tree', TreeView.as_view(), name='collection-tree'),
     re_path('collections/(?P<pk>\d+)', CollectionDetailView.as_view(), name='collection-detail'),
     re_path('objects/(?P<pk>\d+)', ObjectDetailView.as_view(), name='object-detail'),
     path('agents/', AgentListView.as_view(), name='agent-list'),

--- a/viewer/views.py
+++ b/viewer/views.py
@@ -43,3 +43,8 @@ class TermDetailView(DetailView):
 
 class IndexView(TemplateView):
     template_name = 'viewer/index.html'
+
+
+class TreeView(DetailView):
+    model = Collection
+    template_name = 'viewer/collection-tree.html'


### PR DESCRIPTION
Improves load time of collection pages by asynchronously loading trees via AJAX. 

Things to consider/improve:
- Accessibility (you can still navigate down the tree without JS, it's just slower)
- Lag time/responsiveness of show/hide could be improved