### PR TITLE
Improve exception handling

### DIFF
--- a/fetcher/fetchers.py
+++ b/fetcher/fetchers.py
@@ -25,7 +25,7 @@ class BaseDataFetcher:
         try:
             fetched = getattr(
                 self, "get_{}".format(status))(
-                object_type, last_run)
+                object_type, last_run, current_run)
             current_run.status = FetchRun.FINISHED
             current_run.end_time = timezone.now()
             current_run.save()
@@ -38,7 +38,7 @@ class BaseDataFetcher:
                 run=current_run,
                 message=str(e),
             )
-            print(e)
+            raise FetcherError("Error fetching data: {}".format(e))
 
 
 class ArchivesSpaceDataFetcher(BaseDataFetcher):
@@ -49,20 +49,20 @@ class ArchivesSpaceDataFetcher(BaseDataFetcher):
         self.aspace = instantiate_aspace(settings.ARCHIVESSPACE)
         self.transform_url = settings.ARCHIVESSPACE["transform_url"]
 
-    def get_updated(self, object_type, last_run):
+    def get_updated(self, object_type, last_run, current_run):
         data = []
         for u in self.updated_list(object_type, last_run, True):
-            send_post_request(self.transform_url, u.json())
+            send_post_request(self.transform_url, u.json(), current_run)
             data.append(u.uri)
         return data
 
-    def get_deleted(self, object_type, last_run):
+    def get_deleted(self, object_type, last_run, current_run):
         data = []
         for d in self.deleted_list(object_type, last_run):
-            send_post_request(self.transform_url, d)
+            send_post_request(self.transform_url, d, current_run)
             data.append(d)
         for u in self.updated_list(object_type, last_run, False):
-            send_post_request(self.transform_url, u.uri)
+            send_post_request(self.transform_url, u.uri, current_run)
             data.append(u.uri)
         return data
 
@@ -115,21 +115,21 @@ class CartographerDataFetcher(BaseDataFetcher):
             raise FetcherError(
                 "Cartographer is not available.")
 
-    def get_updated(self, object_type, last_run):
+    def get_updated(self, object_type, last_run, current_run):
         data = []
         for map in self.updated_list(last_run, True):
             map_data = self.client.get(map.get('ref')).json()
-            send_post_request(self.transform_url, map_data)
+            send_post_request(self.transform_url, map_data, current_run)
             data.append(map.get('ref'))
         return data
 
-    def get_deleted(self, object_type, last_run):
+    def get_deleted(self, object_type, last_run, current_run):
         data = []
         for map in self.updated_list(last_run, False):
-            send_post_request(self.transform_url, map.get('ref'))
+            send_post_request(self.transform_url, map.get('ref'), current_run)
             data.append(map.get('ref'))
         for uri in self.deleted_list(last_run):
-            send_post_request(self.transform_url, uri)
+            send_post_request(self.transform_url, uri, current_run)
             data.append(uri)
         return data
 

--- a/fetcher/helpers.py
+++ b/fetcher/helpers.py
@@ -2,7 +2,7 @@ import requests
 from asnake.aspace import ASpace
 from pisces import settings
 
-from .models import FetchRun
+from .models import FetchRun, FetchRunError
 
 
 def last_run_time(source, object_type):
@@ -25,13 +25,21 @@ def last_run_time(source, object_type):
         else 0)
 
 
-def send_post_request(url, data):
+def send_post_request(url, data, current_run=None):
     """
     Sends a POST request to a specified URL with a JSON payload.
     """
-    assert(isinstance(data, dict))
-    resp = requests.post(url, json=data)
-    resp.raise_for_status()
+    try:
+        assert(isinstance(data, dict))
+        resp = requests.post(url, json=data)
+        resp.raise_for_status()
+    except Exception as e:
+        print(e)
+        if current_run:
+            FetchRunError.objects.create(
+                run=current_run,
+                message=str(e),
+            )
 
 
 def instantiate_aspace(self, config=None):

--- a/fetcher/tests.py
+++ b/fetcher/tests.py
@@ -61,7 +61,7 @@ class FetcherTest(TestCase):
         for view, status, url_name, object_type_choices, fetcher_vcr, cassette_prefix in [
                 (ArchivesSpaceDeletesView, "deleted", "fetch-archivesspace-deletes", FetchRun.ARCHIVESSPACE_OBJECT_TYPE_CHOICES, archivesspace_vcr, "ArchivesSpace"),
                 (ArchivesSpaceUpdatesView, "updated", "fetch-archivesspace-updates", FetchRun.ARCHIVESSPACE_OBJECT_TYPE_CHOICES, archivesspace_vcr, "ArchivesSpace"),
-                (CartographerDeletesView, "updated", "fetch-cartographer-deletes", FetchRun.CARTOGRAPHER_OBJECT_TYPE_CHOICES, cartographer_vcr, "Cartographer"),
+                (CartographerDeletesView, "deleted", "fetch-cartographer-deletes", FetchRun.CARTOGRAPHER_OBJECT_TYPE_CHOICES, cartographer_vcr, "Cartographer"),
                 (CartographerUpdatesView, "updated", "fetch-cartographer-updates", FetchRun.CARTOGRAPHER_OBJECT_TYPE_CHOICES, cartographer_vcr, "Cartographer")]:
             for object_type in object_type_choices:
                 with fetcher_vcr.use_cassette("{}-{}-{}.json".format(cassette_prefix, status, object_type[0])):

--- a/fixtures/cassettes/fetcher/Cartographer-deleted-arrangement_map.json
+++ b/fixtures/cassettes/fetcher/Cartographer-deleted-arrangement_map.json
@@ -27,23 +27,23 @@
                     "message": "OK"
                 },
                 "headers": {
-                    "Server": [
-                        "WSGIServer/0.2 CPython/3.6.5"
+                    "Content-Type": [
+                        "application/json"
                     ],
                     "X-Frame-Options": [
                         "SAMEORIGIN"
                     ],
-                    "Content-Type": [
-                        "application/json"
+                    "Content-Length": [
+                        "85"
                     ],
                     "Vary": [
                         "Origin"
                     ],
                     "Date": [
-                        "Tue, 25 Feb 2020 19:35:14 GMT"
+                        "Tue, 25 Feb 2020 22:46:20 GMT"
                     ],
-                    "Content-Length": [
-                        "85"
+                    "Server": [
+                        "WSGIServer/0.2 CPython/3.6.5"
                     ]
                 },
                 "body": {
@@ -77,26 +77,26 @@
                     "message": "OK"
                 },
                 "headers": {
-                    "Content-Length": [
-                        "52"
-                    ],
-                    "Server": [
-                        "WSGIServer/0.2 CPython/3.6.5"
-                    ],
                     "Content-Type": [
                         "application/json"
+                    ],
+                    "X-Frame-Options": [
+                        "SAMEORIGIN"
+                    ],
+                    "Content-Length": [
+                        "52"
                     ],
                     "Vary": [
                         "Accept, Cookie, Origin"
                     ],
+                    "Date": [
+                        "Tue, 25 Feb 2020 22:46:20 GMT"
+                    ],
+                    "Server": [
+                        "WSGIServer/0.2 CPython/3.6.5"
+                    ],
                     "Allow": [
                         "GET, POST, HEAD, OPTIONS"
-                    ],
-                    "Date": [
-                        "Tue, 25 Feb 2020 19:35:14 GMT"
-                    ],
-                    "X-Frame-Options": [
-                        "SAMEORIGIN"
                     ]
                 },
                 "body": {
@@ -107,7 +107,7 @@
         {
             "request": {
                 "method": "GET",
-                "uri": "http://cartographer-backend:8000/api/delete-feed/?deleted_since=1582659314",
+                "uri": "http://cartographer-backend:8000/api/delete-feed/?deleted_since=1582670779",
                 "body": null,
                 "headers": {
                     "User-Agent": [
@@ -130,26 +130,26 @@
                     "message": "OK"
                 },
                 "headers": {
-                    "Content-Length": [
-                        "52"
-                    ],
-                    "Server": [
-                        "WSGIServer/0.2 CPython/3.6.5"
-                    ],
                     "Content-Type": [
                         "application/json"
+                    ],
+                    "X-Frame-Options": [
+                        "SAMEORIGIN"
+                    ],
+                    "Content-Length": [
+                        "52"
                     ],
                     "Vary": [
                         "Accept, Cookie, Origin"
                     ],
+                    "Date": [
+                        "Tue, 25 Feb 2020 22:46:20 GMT"
+                    ],
+                    "Server": [
+                        "WSGIServer/0.2 CPython/3.6.5"
+                    ],
                     "Allow": [
                         "GET, HEAD, OPTIONS"
-                    ],
-                    "Date": [
-                        "Tue, 25 Feb 2020 19:35:15 GMT"
-                    ],
-                    "X-Frame-Options": [
-                        "SAMEORIGIN"
                     ]
                 },
                 "body": {

--- a/fixtures/cassettes/fetcher/Cartographer-updated-arrangement_map.json
+++ b/fixtures/cassettes/fetcher/Cartographer-updated-arrangement_map.json
@@ -27,20 +27,20 @@
                     "message": "OK"
                 },
                 "headers": {
+                    "Content-Type": [
+                        "application/json"
+                    ],
                     "Server": [
                         "WSGIServer/0.2 CPython/3.6.5"
                     ],
                     "X-Frame-Options": [
                         "SAMEORIGIN"
                     ],
-                    "Content-Type": [
-                        "application/json"
-                    ],
                     "Vary": [
                         "Origin"
                     ],
                     "Date": [
-                        "Tue, 25 Feb 2020 19:35:14 GMT"
+                        "Tue, 25 Feb 2020 22:53:30 GMT"
                     ],
                     "Content-Length": [
                         "85"
@@ -77,11 +77,8 @@
                     "message": "OK"
                 },
                 "headers": {
-                    "Content-Length": [
-                        "223"
-                    ],
-                    "Server": [
-                        "WSGIServer/0.2 CPython/3.6.5"
+                    "Allow": [
+                        "GET, POST, HEAD, OPTIONS"
                     ],
                     "Content-Type": [
                         "application/json"
@@ -89,14 +86,17 @@
                     "Vary": [
                         "Accept, Cookie, Origin"
                     ],
-                    "Allow": [
-                        "GET, POST, HEAD, OPTIONS"
-                    ],
-                    "Date": [
-                        "Tue, 25 Feb 2020 19:35:14 GMT"
+                    "Server": [
+                        "WSGIServer/0.2 CPython/3.6.5"
                     ],
                     "X-Frame-Options": [
                         "SAMEORIGIN"
+                    ],
+                    "Date": [
+                        "Tue, 25 Feb 2020 22:53:30 GMT"
+                    ],
+                    "Content-Length": [
+                        "223"
                     ]
                 },
                 "body": {
@@ -130,11 +130,8 @@
                     "message": "OK"
                 },
                 "headers": {
-                    "Content-Length": [
-                        "162"
-                    ],
-                    "Server": [
-                        "WSGIServer/0.2 CPython/3.6.5"
+                    "Allow": [
+                        "GET, PUT, PATCH, DELETE, HEAD, OPTIONS"
                     ],
                     "Content-Type": [
                         "application/json"
@@ -142,14 +139,17 @@
                     "Vary": [
                         "Accept, Cookie, Origin"
                     ],
-                    "Allow": [
-                        "GET, PUT, PATCH, DELETE, HEAD, OPTIONS"
-                    ],
-                    "Date": [
-                        "Tue, 25 Feb 2020 19:35:14 GMT"
+                    "Server": [
+                        "WSGIServer/0.2 CPython/3.6.5"
                     ],
                     "X-Frame-Options": [
                         "SAMEORIGIN"
+                    ],
+                    "Date": [
+                        "Tue, 25 Feb 2020 22:53:30 GMT"
+                    ],
+                    "Content-Length": [
+                        "162"
                     ]
                 },
                 "body": {
@@ -189,11 +189,8 @@
                     "message": "OK"
                 },
                 "headers": {
-                    "Content-Length": [
-                        "2"
-                    ],
-                    "Server": [
-                        "WSGIServer/0.2 CPython/3.6.5"
+                    "Allow": [
+                        "POST, OPTIONS"
                     ],
                     "Content-Type": [
                         "application/json"
@@ -201,18 +198,21 @@
                     "Vary": [
                         "Accept, Cookie"
                     ],
-                    "Allow": [
-                        "POST, OPTIONS"
-                    ],
-                    "Date": [
-                        "Tue, 25 Feb 2020 19:35:14 GMT"
+                    "Server": [
+                        "WSGIServer/0.2 CPython/3.6.5"
                     ],
                     "X-Frame-Options": [
                         "SAMEORIGIN"
+                    ],
+                    "Date": [
+                        "Tue, 25 Feb 2020 22:53:30 GMT"
+                    ],
+                    "Content-Length": [
+                        "19"
                     ]
                 },
                 "body": {
-                    "string": "{}"
+                    "string": "[\"detail: success\"]"
                 }
             }
         }

--- a/pisces/urls.py
+++ b/pisces/urls.py
@@ -20,7 +20,8 @@ from fetcher.views import (ArchivesSpaceDeletesView, ArchivesSpaceUpdatesView,
                            FetchRunViewSet)
 from rest_framework import routers
 from rest_framework.schemas import get_schema_view
-from transformer.views import ArchivesSpaceTransformView
+from transformer.views import (ArchivesSpaceTransformView,
+                               CartographerTransformView)
 
 router = routers.DefaultRouter()
 router.register(r'fetches', FetchRunViewSet, 'fetchrun')
@@ -38,6 +39,7 @@ urlpatterns = [
     re_path(r'^fetch/cartographer/updates/$', CartographerUpdatesView.as_view(), name='fetch-cartographer-updates'),
     re_path(r'^fetch/cartographer/deletes/$', CartographerDeletesView.as_view(), name='fetch-cartographer-deletes'),
     re_path(r'^transform/archivesspace/$', ArchivesSpaceTransformView.as_view(), name='transform-archivesspace'),
+    re_path(r'^transform/cartographer/$', CartographerTransformView.as_view(), name='transform-cartographer'),
     path('status/', include('health_check.api.urls')),
     path('schema/', schema_view, name='schema'),
     path('', include(router.urls)),

--- a/transformer/views.py
+++ b/transformer/views.py
@@ -15,3 +15,15 @@ class ArchivesSpaceTransformView(APIView):
             return Response(resp, status=200)
         except Exception as e:
             return Response({"detail": str(e)}, status=500)
+
+
+class CartographerTransformView(APIView):
+    """Takes the get request for AS data and returns a web response based on the transformation of that data."""
+
+    def post(self, request, format=None):
+        try:
+            if not request.data:
+                return Response({"detail": "Missing request data"}, status=500)
+            return Response({"detail: success"}, status=200)
+        except Exception as e:
+            return Response({"detail": str(e)}, status=500)


### PR DESCRIPTION
Note: I left the exception handling on `BaseDataFetcher` in place, as it's possible for other failures to occur outside of the transformation POST request.

fixes #185 