### PR TITLE
Removes Odin keys from data before persisting

### DIFF
--- a/transformer/tests.py
+++ b/transformer/tests.py
@@ -85,6 +85,8 @@ class TransformerTest(TestCase):
                     self.assertEqual(response.data["count"], len(DataObject.objects.filter(object_type=action.rstrip("s"))))
                 else:
                     self.assertEqual(response.data["count"] + 1, len(DataObject.objects.filter(object_type=action.rstrip("s"))))
+                for obj in response.data["results"]:
+                    self.assertTrue("$" not in obj, "Odin mapping keys were not removed from data.")
 
     def test_transformer(self):
         self.mappings()


### PR DESCRIPTION
Removes `$` keys, which are generated by Odin so data can be easily re-serialized, before saving data.

fixes #220 