### PR TITLE
Adds view to update DataObject after indexing action

### DIFF
--- a/pisces/urls.py
+++ b/pisces/urls.py
@@ -20,7 +20,8 @@ from fetcher.views import (ArchivesSpaceDeletesView, ArchivesSpaceUpdatesView,
                            FetchRunViewSet)
 from merger.views import MergeView
 from rest_framework.schemas import get_schema_view
-from transformer.views import DataObjectViewSet, TransformView
+from transformer.views import (DataObjectUpdateByIdView, DataObjectViewSet,
+                               TransformView)
 
 from .routers import PiscesRouter
 
@@ -42,6 +43,7 @@ urlpatterns = [
     re_path(r'^fetch/cartographer/deletes/$', CartographerDeletesView.as_view(), name='fetch-cartographer-deletes'),
     re_path(r'^merge/$', MergeView.as_view(), name='merge'),
     re_path(r'^transform/$', TransformView.as_view(), name='transform'),
+    re_path(r'^index-complete/$', DataObjectUpdateByIdView.as_view(), name='index-action-complete'),
     re_path(r'^silk/', include('silk.urls', namespace='silk')),
     path('status/', include('health_check.api.urls')),
     path('schema/', schema_view, name='schema'),

--- a/transformer/views.py
+++ b/transformer/views.py
@@ -58,3 +58,25 @@ class DataObjectViewSet(ModelViewSet):
     @action(detail=False)
     def terms(self, request):
         return self.get_action_response(request, "term")
+
+
+class DataObjectUpdateByIdView(BaseServiceView):
+    """Updates DataObjects after they have been indexed.
+
+    Finds a DataObject by its es_id field and sets indexed to True.
+    """
+
+    def get_service_response(self, request):
+        es_id = request.data.get("identifier")
+        action = request.data.get("action")
+        if action not in ["deleted", "indexed"]:
+            raise Exception("Unrecognized action {}, expecting either `deleted` or `indexed`")
+        obj = DataObject.objects.get(es_id=es_id)
+        if action == "indexed":
+            obj.indexed = True
+            obj.save()
+            msg = "{} {} marked as indexed.".format(obj.object_type, obj.pk)
+        else:
+            obj.delete()
+            msg = "{} {} deleted.".format(obj.object_type, obj.pk)
+        return msg


### PR DESCRIPTION
Adds an endpoint which can be POSTed to after indexing actions are complete. Requires request data to be sent along with it:
```
{
  "identifier": "123adf2asdf",
  "action": "indexed"
}
```

fixes #243 