### PR TITLE
Convert items field to ArrayField

### DIFF
--- a/fixtures/merger/resource/363.json
+++ b/fixtures/merger/resource/363.json
@@ -166,7 +166,7 @@
                         {
                             "event_date": "1927-1929 ",
                             "events": [
-                                "General Education Board Fellow at Columbia University with Thomas Hunt Morgan"
+                                "General Education Board Fellow at \"Columbia University\" with Thomas Hunt Morgan"
                             ]
                         },
                         {
@@ -269,7 +269,7 @@
                         {
                             "event_date": "1969 ",
                             "events": [
-                                "Gold Medal for Distinguished Achievement of Science, American Museum of Natural History"
+                                "Gold Medal for Distinguished Achievement of Science, \"American Museum of Natural History\""
                             ]
                         },
                         {

--- a/fixtures/merger/resource/397.json
+++ b/fixtures/merger/resource/397.json
@@ -260,8 +260,8 @@
                             "value": "value"
                         },
                         {
-                            "label": "another label",
-                            "value": "yet another value"
+                            "label": "another's label",
+                            "value": "yet \"another\" value"
                         }
                     ]
                 },
@@ -272,7 +272,7 @@
                     "publish": true,
                     "items": [
                         "apples",
-                        "oranges",
+                        "oranges \"and\" plums",
                         "pears",
                         "grapes"
                     ]

--- a/fixtures/transformer/resource/12725.json
+++ b/fixtures/transformer/resource/12725.json
@@ -435,7 +435,7 @@
         },
         {
             "content": [
-                "Malcolm P. Aldrich served as the second President of the Commonwealth Fund, succeeding Edward S. Harkness, and Chairman of the Fund's Board. As head of the Fund he actively promoted medical education and facilitated the builing of a new wing at the Eye Institute at Columbia Presbyterian Medical Center."
+                "Malcolm P. Aldrich served as the second President of the \"Commonwealth Fund\", succeeding Edward S. Harkness, and Chairman of the Fund's Board. As head of the Fund he actively promoted medical education and facilitated the builing of a new wing at the Eye Institute at Columbia Presbyterian Medical Center."
             ],
             "items": [],
             "jsonmodel_type": "note_bibliography",

--- a/fixtures/transformer/resource/363.json
+++ b/fixtures/transformer/resource/363.json
@@ -276,7 +276,7 @@
                         {
                             "event_date": "1946 ",
                             "events": [
-                                "Daniel Giraud Elliot Medal NAS"
+                                "Daniel \"Giraud Elliot\" Medal NAS"
                             ]
                         },
                         {
@@ -318,7 +318,7 @@
                         {
                             "event_date": "1969 ",
                             "events": [
-                                "Gold Medal for Distinguished Achievement of Science, American Museum of Natural History"
+                                "Gold Medal for Distinguished Achievement of Science, \"American Museum of Natural History\""
                             ]
                         },
                         {

--- a/fixtures/transformer/resource/397.json
+++ b/fixtures/transformer/resource/397.json
@@ -279,7 +279,7 @@
                         },
                         {
                             "label": "another label",
-                            "value": "yet another value"
+                            "value": "yet \"another\" value"
                         }
                     ],
                     "jsonmodel_type": "note_definedlist",
@@ -290,7 +290,7 @@
                     "enumeration": "arabic",
                     "items": [
                         "apples",
-                        "oranges",
+                        "oranges \"and\" peaches",
                         "pears",
                         "grapes"
                     ],

--- a/fixtures/transformer/resource/721.json
+++ b/fixtures/transformer/resource/721.json
@@ -187,7 +187,7 @@
         },
         {
             "content": [
-                "Arranged in 3 series:\n1. Administrative Files.\n2. S. David Freeman Files.\n3. EPP Reports."
+                "Arranged in 3 series:\n1. \"Administrative Files\".\n2. S. David Freeman Files.\n3. EPP Reports."
             ],
             "items": [],
             "jsonmodel_type": "note_bibliography",

--- a/transformer/mappings.py
+++ b/transformer/mappings.py
@@ -157,13 +157,9 @@ class SourceNoteToNote(odin.Mapping):
     def map_subnotes(self, value):
         """Maps Subnotes to values based on the note type."""
         if value.jsonmodel_type == 'note_definedlist':
-            # items is an odin.StringField so we need to re-convert to a dict here
-            items = literal_eval(value.items.encode('unicode-escape').decode())
-            subnote = Subnote(type=value.jsonmodel_type.split('note_')[1], items=items)
+            subnote = Subnote(type=value.jsonmodel_type.split('note_')[1], items=value.items)
         elif value.jsonmodel_type == 'note_orderedlist':
-            # items is an odin.StringField so we need to re-convert to a dict here
-            items = literal_eval(value.items.encode('unicode-escape').decode())
-            items_list = [{idx: item} for idx, item in enumerate(items)]
+            items_list = [{idx: item} for idx, item in enumerate(value.items)]
             subnote = Subnote(type=value.jsonmodel_type.split('note_')[1], items=items_list)
         elif value == 'note_bibliography':
             subnote = self.bibliograpy_subnotes(value.content, value.items)
@@ -183,8 +179,7 @@ class SourceNoteToNote(odin.Mapping):
         if self.source.jsonmodel_type in ['note_multipart', 'note_bioghist']:
             subnotes = (self.map_subnotes(v) for v in value)
         elif self.source.jsonmodel_type in ['note_singlepart', 'note_rights_statement', 'note_rights_statement_act']:
-            content = literal_eval(self.source.content.encode('unicode-escape').decode())
-            subnotes = [Subnote(type='text', content=content)]
+            subnotes = [Subnote(type='text', content=self.source.content)]
         elif self.source.jsonmodel_type == 'note_index':
             subnotes = self.index_subnotes(self.source.content, self.source.items)
         elif self.source.jsonmodel_type == 'note_bibliography':
@@ -202,16 +197,12 @@ class SourceNoteToNote(odin.Mapping):
 
     def index_subnotes(self, content, items):
         data = []
-        # items is an odin.StringField so we need to re-convert to a dict here
-        items_dict = literal_eval(items.encode('unicode-escape').decode())
-        items_list = [{'label': i.get('type'), 'value': i.get('value')} for i in items_dict]
+        items_list = [{'label': i.get('type'), 'value': i.get('value')} for i in items]
         data.append(Subnote(type='text', content=json.loads(content)))
         data.append(Subnote(type='definedlist', items=items_list))
         return data
 
     def chronology_subnotes(self, items):
-        # items is an odin.StringField so we need to re-convert to a dict here
-        items = literal_eval(items.encode('unicode-escape').decode())
         items_list = [{'label': i.get('event_date'), 'value': i.get('events')} for i in items]
         return Subnote(type='definedlist', items=items_list)
 

--- a/transformer/resources/source.py
+++ b/transformer/resources/source.py
@@ -122,7 +122,7 @@ class SourceSubnote(odin.Resource):
     """Contains note content."""
     jsonmodel_type = odin.StringField()
     content = odin.StringField(null=True)
-    items = odin.StringField(null=True)
+    items = odin.ArrayField(null=True)
 
 
 class SourceNote(odin.Resource):


### PR DESCRIPTION
Tweaks fixtures to ensure cases with double quotes are covered, also removes use of `literal_eval`.

fixes #256 