### PR TITLE
Return display name for source

### DIFF
--- a/fetcher/helpers.py
+++ b/fetcher/helpers.py
@@ -113,7 +113,7 @@ def send_error_notification(fetch_run):
         errors = ""
         err_str = "errors" if fetch_run.error_count > 1 else "error"
         object_type = fetch_run.get_object_type_display()
-        source = fetch_run.get_source_display()
+        source = [s[1] for s in FetchRun.SOURCE_CHOICES if s[0] == fetch_run.source][0]
         for err in fetch_run.errors:
             errors += "{}\n".format(err.message)
         send_mail(

--- a/fetcher/tests.py
+++ b/fetcher/tests.py
@@ -127,6 +127,7 @@ class FetcherTest(TestCase):
         send_error_notification(fetch_run)
         self.assertEqual(len(mail.outbox), 1)
         self.assertIn(fetch_run.get_object_type_display(), mail.outbox[0].subject)
-        self.assertIn(fetch_run.get_source_display(), mail.outbox[0].subject)
+        source = [s[1] for s in FetchRun.SOURCE_CHOICES if s[0] == fetch_run.source][0]
+        self.assertIn(source, mail.outbox[0].subject)
         self.assertNotIn("errors", mail.outbox[0].subject)
         self.assertIn(error.message, mail.outbox[0].body)


### PR DESCRIPTION
Returns the human-readable name for a source in emails

fixes #285 