### PR TITLE
Handles resources with no trees

### DIFF
--- a/fixtures/cassettes/merger/resource-merge.json
+++ b/fixtures/cassettes/merger/resource-merge.json
@@ -739,7 +739,7 @@
                     ]
                 },
                 "body": {
-                    "string": "{\"child_count\":1,\"waypoints\":1,\"waypoint_size\":200,\"title\":\"Rockefeller University records, Special Events and Activities, Medical Electronics Center\",\"uri\":\"/repositories/2/resources/1008\",\"slugged_url\":\"\",\"jsonmodel_type\":\"resource\",\"parsed_title\":\"Rockefeller University records, Special Events and Activities, Medical Electronics Center\",\"level\":\"collection\",\"precomputed_waypoints\":{\"\":{\"0\":[{\"child_count\":0,\"waypoints\":0,\"waypoint_size\":200,\"title\":\"Bibliography\",\"slugged_url\":\"\",\"parsed_title\":\"Bibliography\",\"uri\":\"/repositories/2/archival_objects/559590\",\"position\":0,\"parent_id\":null,\"jsonmodel_type\":\"archival_object\",\"level\":\"file\",\"dates\":[{\"type\":\"inclusive\",\"label\":\"creation\",\"expression\":\"1958-1959\",\"begin\":\"1958\",\"end\":\"1959\"}]}]}}}\n"
+                    "string": "{\"child_count\":0,\"waypoints\":0,\"waypoint_size\":200,\"title\":\"Rockefeller University records, Special Events and Activities, Medical Electronics Center\",\"uri\":\"/repositories/2/resources/1008\",\"slugged_url\":\"\",\"jsonmodel_type\":\"resource\",\"parsed_title\":\"Rockefeller University records, Special Events and Activities, Medical Electronics Center\",\"level\":\"collection\",\"precomputed_waypoints\":{}}"
                 }
             }
         },

--- a/merger/helpers.py
+++ b/merger/helpers.py
@@ -57,7 +57,7 @@ class ArchivesSpaceHelper:
     def get_resource_children(self, uri):
         tree_root = self.aspace.client.get(
             "{}/tree/root".format(uri.rstrip("/"))).json()
-        return self.tree_children(tree_root, "")
+        return self.tree_children(tree_root, "") if tree_root["child_count"] > 0 else []
 
     @silk_profile()
     def get_archival_object_children(self, resource_uri, object_uri):


### PR DESCRIPTION
Adds logic to return empty list when no children are present, edits cassette to test this case.

fixes #289 