### PR TITLE
Target list rather than single ID in DataObjectUpdateByIdView

### DIFF
--- a/deploy_scripts/make_zip.sh
+++ b/deploy_scripts/make_zip.sh
@@ -4,24 +4,28 @@ set -e
 ZIP_DIR=$1
 ZIP_NAME=$2
 
-# remove unnecessary files
-rm -rf fixtures \
-  .git \
-  .github \
-  .coverage \
-  .flake8 \
-  .gitignore \
-  .pre-commit-config.yaml \
-  cc-test-reporter \
-  coverage.xml \
-  docker-compose.yml \
-  Dockerfile \
-  entrypoint.sh \
-  pisces-services.png \
-  wait-for-it.sh
-find . -type d -name __pycache__ -exec rm -r {} \+
+if [ ! -f $ZIP_DIR/$ZIP_NAME ]; then
 
-# create zip file
-zip -r $ZIP_NAME .
-mkdir -p $ZIP_DIR
-mv $ZIP_NAME $ZIP_DIR/$ZIP_NAME
+  # remove unnecessary files
+  rm -rf fixtures \
+    .git \
+    .github \
+    .coverage \
+    .flake8 \
+    .gitignore \
+    .pre-commit-config.yaml \
+    cc-test-reporter \
+    coverage.xml \
+    docker-compose.yml \
+    Dockerfile \
+    entrypoint.sh \
+    pisces-services.png \
+    wait-for-it.sh
+  find . -type d -name __pycache__ -exec rm -r {} \+
+
+  # create zip file
+  zip -r $ZIP_NAME .
+  mkdir -p $ZIP_DIR
+  mv $ZIP_NAME $ZIP_DIR/$ZIP_NAME
+  
+fi

--- a/transformer/tests.py
+++ b/transformer/tests.py
@@ -101,7 +101,7 @@ class TransformerTest(TestCase):
                 obj_len = len(DataObject.objects.filter(object_type=object_type))
                 request = client.post(
                     reverse("index-action-complete"),
-                    data={"identifier": obj.es_id, "action": action},
+                    data={"identifiers": [obj.es_id], "action": action},
                     format="json")
                 response = DataObjectUpdateByIdView.as_view()(request)
                 self.assertEqual(

--- a/transformer/views.py
+++ b/transformer/views.py
@@ -55,19 +55,22 @@ class DataObjectUpdateByIdView(BaseServiceView):
     """
 
     def get_service_response(self, request):
-        es_id = request.data.get("identifier")
+        identifiers = request.data.get("identifiers")
         action = request.data.get("action")
+        msg = ""
         if action not in ["deleted", "indexed"]:
             raise Exception("Unrecognized action {}, expecting either `deleted` or `indexed`")
-        try:
-            obj = DataObject.objects.get(es_id=es_id)
-            if action == "indexed":
-                obj.indexed = True
-                obj.save()
-                msg = "{} {} marked as indexed.".format(obj.object_type, obj.pk)
-            else:
-                obj.delete()
-                msg = "{} {} deleted.".format(obj.object_type, obj.pk)
-        except DataObject.DoesNotExist:
-            raise Exception("Could not find DataObject with identifier {}".format(es_id))
+        for es_id in identifiers:
+            try:
+                obj = DataObject.objects.get(es_id=es_id)
+                if action == "indexed":
+                    obj.indexed = True
+                    obj.save()
+                else:
+                    obj.delete()
+            except DataObject.DoesNotExist:
+                msg += "Could not find DataObject with identifier {}, skipping".format(es_id)
+        msg += "{} {} {}.".format(
+            obj.object_type, obj.pk,
+            "marked as indexed" if action == "indexed" else "deleted")
         return msg


### PR DESCRIPTION
`DataObjectUpdateByIdView` has been updated so it iterates over a list of IDs rather than acting on just a single ID. This supports changes in Pisces.

fixes #291 