### PR TITLE
Adds cron to clean up old FetchRun objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,3 +53,5 @@ deploy:
   deployment_group: PiscesDevelopment
   region: us-east-1
   on: *development
+notifications:
+  email: false

--- a/fetcher/cron.py
+++ b/fetcher/cron.py
@@ -127,3 +127,20 @@ class UpdatedCartographerArrangementMapComponents(BaseCron):
     object_status = "updated"
     object_type = "arrangement_map_component"
     fetcher = CartographerDataFetcher
+
+
+class CleanUpCompleted(CronJobBase):
+    RUN_EVERY_MINS = 0
+    schedule = Schedule(run_every_mins=RUN_EVERY_MINS)
+
+    def do(self):
+        try:
+            for obj_type in FetchRun.OBJECT_TYPE_CHOICES:
+                delete_ids = FetchRun.objects.filter(
+                    object_type=obj_type,
+                    status=FetchRun.FINISHED,
+                    fetchrunerror__isnull=True).order_by("-end_time")[1:].values_list("id", flat=True)
+                FetchRun.objects.filter(pk__in=list(delete_ids)).delete()
+        except Exception as e:
+            print("Error cleaning  up completed FetchRun objects: {}".format(e))
+            return False

--- a/fetcher/tests.py
+++ b/fetcher/tests.py
@@ -8,8 +8,7 @@ from django.test import TestCase
 from django.utils import timezone
 from rest_framework.test import APIRequestFactory
 
-from .cron import (CleanUpCompleted,
-                   DeletedArchivesSpaceArchivalObjects,
+from .cron import (CleanUpCompleted, DeletedArchivesSpaceArchivalObjects,
                    DeletedArchivesSpaceFamilies,
                    DeletedArchivesSpaceOrganizations,
                    DeletedArchivesSpacePeople, DeletedArchivesSpaceResources,
@@ -143,4 +142,4 @@ class FetcherTest(TestCase):
                 self.assertEqual(last_run, last_run_time(source, FetchRun.FINISHED, object))
                 print(object)
                 self.assertEqual(
-                    len(FetchRun.objects.filter(source=source_id, object_type=object[0],status=FetchRun.FINISHED)), 2)
+                    len(FetchRun.objects.filter(source=source_id, object_type=object[0], status=FetchRun.FINISHED)), 2)

--- a/fetcher/tests.py
+++ b/fetcher/tests.py
@@ -8,7 +8,8 @@ from django.test import TestCase
 from django.utils import timezone
 from rest_framework.test import APIRequestFactory
 
-from .cron import (DeletedArchivesSpaceArchivalObjects,
+from .cron import (CleanUpCompleted,
+                   DeletedArchivesSpaceArchivalObjects,
                    DeletedArchivesSpaceFamilies,
                    DeletedArchivesSpaceOrganizations,
                    DeletedArchivesSpacePeople, DeletedArchivesSpaceResources,
@@ -49,15 +50,16 @@ class FetcherTest(TestCase):
         self.factory = APIRequestFactory()
         time = pytz.utc.localize(datetime(2020, 3, 1))
         for object_status, _ in FetchRun.OBJECT_STATUS_CHOICES:
-            for object_type, _ in FetchRun.ARCHIVESSPACE_OBJECT_TYPE_CHOICES:
-                f = FetchRun.objects.create(
-                    status=FetchRun.FINISHED,
-                    source=FetchRun.ARCHIVESSPACE,
-                    object_type=object_type,
-                    object_status=object_status
-                )
-                f.start_time = time
-                f.save()
+            for _, source in FetchRun.SOURCE_CHOICES:
+                for object_type, _ in getattr(FetchRun, "{}_OBJECT_TYPE_CHOICES".format(source.upper())):
+                    f = FetchRun.objects.create(
+                        status=FetchRun.FINISHED,
+                        source=getattr(FetchRun, source.upper()),
+                        object_type=object_type,
+                        object_status=object_status
+                    )
+                    f.start_time = time
+                    f.save()
 
     def test_fetchers(self):
         for object_type_choices, fetcher, fetcher_vcr, cassette_prefix in [
@@ -131,3 +133,14 @@ class FetcherTest(TestCase):
         self.assertIn(source, mail.outbox[0].subject)
         self.assertNotIn("errors", mail.outbox[0].subject)
         self.assertIn(error.message, mail.outbox[0].body)
+
+    def test_cleanup(self):
+        for source_id, source in FetchRun.SOURCE_CHOICES:
+            for object in getattr(FetchRun, "{}_OBJECT_TYPE_CHOICES".format(source.upper())):
+                last_run = last_run_time(source, FetchRun.FINISHED, object)
+                cleanup = CleanUpCompleted().do()
+                self.assertIsNot(False, cleanup)
+                self.assertEqual(last_run, last_run_time(source, FetchRun.FINISHED, object))
+                print(object)
+                self.assertEqual(
+                    len(FetchRun.objects.filter(source=source_id, object_type=object[0],status=FetchRun.FINISHED)), 2)


### PR DESCRIPTION
Decided to add another cron because it allows us to keep this functionality completely isolated from other app functionality.

fixes #284 
