### PR TITLE
parse instances to get extent

### DIFF
--- a/fetcher/fetchers.py
+++ b/fetcher/fetchers.py
@@ -38,11 +38,9 @@ class BaseDataFetcher:
         self.processed = 0
         merger = self.get_merger(object_type)
         try:
-            print("Starting Fetch")
             fetched = getattr(
                 self, "get_{}".format(object_status))(
                 clients, object_type, last_run, current_run)
-            print("Fetch finished")
         except Exception as e:
             current_run.status = FetchRun.ERRORED
             current_run.end_time = timezone.now()
@@ -53,7 +51,6 @@ class BaseDataFetcher:
             )
             raise FetcherError(e)
 
-        print("Calling async.io")
         asyncio.get_event_loop().run_until_complete(
             self.process_chunks(
                 fetched, merger, object_type, clients, current_run))

--- a/fetcher/tests.py
+++ b/fetcher/tests.py
@@ -68,7 +68,7 @@ class FetcherTest(TestCase):
                 for object_type, _ in object_type_choices:
                     with fetcher_vcr.use_cassette("{}-{}-{}.json".format(cassette_prefix, status, object_type)):
                         processed = fetcher().fetch(status, object_type)
-                        print(object_type, processed)
+                        self.assertTrue(isinstance(processed, int))
             self.assertTrue(len(FetchRun.objects.all()), len(object_type_choices) * 2)
 
     def test_action_views(self):

--- a/fixtures/merger/archival_object/11441.json
+++ b/fixtures/merger/archival_object/11441.json
@@ -118,7 +118,7 @@
       "is_representative": false,
       "sub_container": {
         "lock_version": 0,
-        "indicator_2": "1",
+        "indicator_2": "1-5",
         "created_by": "pgalligan",
         "last_modified_by": "pgalligan",
         "create_time": "2017-02-16T22:48:46Z",

--- a/fixtures/transformer/archival_object/11441.json
+++ b/fixtures/transformer/archival_object/11441.json
@@ -27,7 +27,12 @@
         }
     ],
     "display_string": "Sculpture for the Pan American Highway, 1954",
-    "extents": [],
+    "extents": [
+      {
+        "number": "4",
+        "extent_type": "folders"
+      }
+    ],
     "external_documents": [],
     "external_ids": [
         {

--- a/merger/mergers.py
+++ b/merger/mergers.py
@@ -113,18 +113,34 @@ class ArchivalObjectMerger(BaseMerger):
                 object["uri"], "language")
         return data
 
+    def get_extent_data(self, object, data):
+        data["extents"] = object.get("extents")
+        if not data["extents"]:
+            if object.get("instances"):
+                extents = []
+                for instance in object["instances"]:
+                    extent = {}
+                    range = sorted([int(i.strip()) for i in instance["sub_container"]["indicator_2"].split("-")])
+                    number = range[-1] - range[0] if len(range) > 1 else 1
+                    type = instance["sub_container"]["type_2"]
+                    extent["extent_type"] = "{}s".format(type)
+                    extent["number"] = number
+                    extents.append(extent)
+                data["extents"] = extents
+            else:
+                data["extents"] = self.aspace_helper.closest_parent_value(object["uri"], "extents")
+        return data
+
     @silk_profile()
     def get_archivesspace_data(self, object, object_type):
         """Gets dates, languages, extent and children from archival object's
         resource record in ArchivesSpace.
         """
         data = {"linked_agents": [], "children": []}
-        fields = ["dates"] if object_type == "archival_object" else ["dates", "extents"]
-        for field in fields:
-            if object.get(field) in ["", [], {}, None]:
-                value = self.aspace_helper.closest_parent_value(object["uri"], field)
-                data[field] = value
-        data = self.get_language_data(object, data)
+        if object.get("dates") in ["", [], {}, None]:
+            data["dates"] = self.aspace_helper.closest_parent_value(object["uri"], "dates")
+        data.update(self.get_language_data(object, data))
+        data.update(self.get_extent_data(object, data))
         if object_type == "archival_object_collection":
             data.update(self.get_archival_object_collection_data(object))
         return data

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ pyrsistent==0.15.7
 python-dateutil==2.8.1
 pytz==2019.3
 PyYAML==5.3
-rac_schemas==0.7
+rac_schemas==0.9
 requests==2.23.0
 shortuuid==0.5.0
 six==1.12.0

--- a/transformer/mappings.py
+++ b/transformer/mappings.py
@@ -262,17 +262,17 @@ class SourceArchivalObjectToCollection(odin.Mapping):
     def terms(self, value):
         return SourceRefToReference.apply(value)
 
-    @odin.map_list_field(from_field='dates', to_field='dates')
-    def dates(self, value):
-        return SourceDateToDate.apply(value)
+    # @odin.map_list_field(from_field='dates', to_field='dates')
+    # def dates(self, value):
+    #     return SourceDateToDate.apply(value)
 
     @odin.map_list_field(from_field='rights_statements', to_field='rights')
     def rights(self, value):
         return SourceRightsStatementToRightsStatement.apply(value)
 
-    @odin.map_list_field(from_field='extents', to_field='extents')
-    def extents(self, value):
-        return SourceExtentToExtent.apply(value)
+    # @odin.map_list_field(from_field='extents', to_field='extents')
+    # def extents(self, value):
+    #     return SourceExtentToExtent.apply(value)
 
     @odin.map_list_field(from_field='linked_agents', to_field='creators')
     def creators(self, value):

--- a/transformer/resources/configs.py
+++ b/transformer/resources/configs.py
@@ -337,7 +337,7 @@ EXTENT_TYPE_CHOICES = (
     ('document box(es)', 'Document Boxes'),
     ('files', 'Files'),
     ('film reels', 'Film Reels'),
-    ('folder(s)', 'Folder(s)'),
+    ('folders', 'Folders'),
     ('gigabytes', 'Gigabytes'),
     ('images', 'Images'),
     ('Item(s)', 'Item(s)'),


### PR DESCRIPTION
Updates extent parsing:
- first attempts to parse an instance to produce an extent (such as `1 folder`, `3 reels`)
- If an instance isn't available, looks for the next closest parent instance.

fixes #300 
