### PR TITLE
Transform only select note types

### DIFF
--- a/transformer/mappings.py
+++ b/transformer/mappings.py
@@ -5,7 +5,7 @@ from fetcher.helpers import identifier_from_uri
 from iso639 import languages
 from pisces import settings
 
-from .resources.configs import NOTE_TYPE_CHOICES
+from .resources.configs import NOTE_TYPE_CHOICES, NOTE_TYPE_CHOICES_TRANSFORM
 from .resources.rac import (Agent, AgentReference, Collection, Date, Extent,
                             ExternalIdentifier, Group, Language, Note, Object,
                             RecordReference, Subnote, Term, TermReference)
@@ -270,7 +270,7 @@ class SourceResourceToCollection(odin.Mapping):
 
     @odin.map_list_field(from_field="notes", to_field="notes", to_list=True)
     def notes(self, value):
-        return SourceNoteToNote.apply([v for v in value if v.publish])
+        return SourceNoteToNote.apply([v for v in value if (v.publish and v.jsonmodel_type in NOTE_TYPE_CHOICES_TRANSFORM)])
 
     @odin.map_list_field(from_field="dates", to_field="dates")
     def dates(self, value):
@@ -328,7 +328,7 @@ class SourceArchivalObjectToCollection(odin.Mapping):
 
     @odin.map_list_field(from_field="notes", to_field="notes", to_list=True)
     def notes(self, value):
-        return SourceNoteToNote.apply([v for v in value if v.publish])
+        return SourceNoteToNote.apply([v for v in value if (v.publish and v.jsonmodel_type in NOTE_TYPE_CHOICES_TRANSFORM)])
 
     @odin.map_field
     def title(self, value):
@@ -393,7 +393,7 @@ class SourceArchivalObjectToObject(odin.Mapping):
 
     @odin.map_list_field(from_field="notes", to_field="notes", to_list=True)
     def notes(self, value):
-        return SourceNoteToNote.apply([v for v in value if v.publish])
+        return SourceNoteToNote.apply([v for v in value if (v.publish and v.jsonmodel_type in NOTE_TYPE_CHOICES_TRANSFORM)])
 
     @odin.map_list_field(from_field="dates", to_field="dates")
     def dates(self, value):
@@ -499,7 +499,7 @@ class SourceAgentCorporateEntityToAgent(odin.Mapping):
 
     @odin.map_list_field(from_field="notes", to_field="notes", to_list=True)
     def notes(self, value):
-        return SourceNoteToNote.apply([v for v in value if v.publish])
+        return SourceNoteToNote.apply([v for v in value if (v.publish and v.jsonmodel_type in NOTE_TYPE_CHOICES_TRANSFORM)])
 
     @odin.map_list_field(from_field="dates_of_existence", to_field="dates")
     def dates(self, value):
@@ -559,7 +559,7 @@ class SourceAgentFamilyToAgent(odin.Mapping):
 
     @odin.map_list_field(from_field="notes", to_field="notes", to_list=True)
     def notes(self, value):
-        return SourceNoteToNote.apply([v for v in value if v.publish])
+        return SourceNoteToNote.apply([v for v in value if (v.publish and v.jsonmodel_type in NOTE_TYPE_CHOICES_TRANSFORM)])
 
     @odin.map_list_field(from_field="dates_of_existence", to_field="dates")
     def dates(self, value):
@@ -619,7 +619,7 @@ class SourceAgentPersonToAgent(odin.Mapping):
 
     @odin.map_list_field(from_field="notes", to_field="notes", to_list=True)
     def notes(self, value):
-        return SourceNoteToNote.apply([v for v in value if v.publish])
+        return SourceNoteToNote.apply([v for v in value if (v.publish and v.jsonmodel_type in NOTE_TYPE_CHOICES_TRANSFORM)])
 
     @odin.map_list_field(from_field="dates_of_existence", to_field="dates")
     def dates(self, value):

--- a/transformer/resources/configs.py
+++ b/transformer/resources/configs.py
@@ -420,6 +420,18 @@ NOTE_TYPE_CHOICES = (
     ('userestrict', 'Conditions Governing Use'),
 )
 
+NOTE_TYPE_CHOICES_TRANSFORM = (
+    ('abstract', 'Abstract'),
+    ('accessrestrict', 'Conditions Governing Access'),
+    ('arrangement', 'Arrangement'),
+    ('bioghist', 'Biographical / Historical'),
+    ('materialspec', 'Materials Specific Details'),
+    ('physdesc', 'Physical Description'),
+    ('processinfo', 'Processing Information'),
+    ('scopecontent', 'Scope and Contents'),
+    ('userestrict', 'Conditions Governing Use'),
+)
+
 REFERENCE_TYPE_CHOICES = (
     ("cultural_context", "Cultural Context"),
     ("function", "Function"),

--- a/transformer/tests.py
+++ b/transformer/tests.py
@@ -8,6 +8,7 @@ from fetcher.helpers import identifier_from_uri
 from rest_framework.test import APIRequestFactory
 
 from .models import DataObject
+from .resources.configs import NOTE_TYPE_CHOICES_TRANSFORM
 from .transformers import Transformer
 from .views import DataObjectUpdateByIdView, DataObjectViewSet
 
@@ -54,7 +55,9 @@ class TransformerTest(TestCase):
                                             (date_source_key, "dates"),
                                             ("extents", "extents"),
                                             ("children", "children")]:
-            source_len = len([n for n in source.get(source_key, []) if n["publish"]]) if source_key == "notes" else len(source.get(source_key, []))
+            source_len = len(
+                [n for n in source.get(source_key, []) if (n["publish"] and n["jsonmodel_type"] in NOTE_TYPE_CHOICES_TRANSFORM)]
+            ) if source_key == "notes" else len(source.get(source_key, []))
             transformed_len = len(transformed.get(transformed_key, []))
             self.assertEqual(source_len, transformed_len,
                              "Found {} {} in source but {} {} in transformed.".format(


### PR DESCRIPTION
Adds an explicit list of note types to transform. This decreases the overall size of objects and collections, and ensures more accurate search results.