### PR TITLE
Pass instead of raising exception for missing archival objects in merger

### DIFF
--- a/merger/helpers.py
+++ b/merger/helpers.py
@@ -4,6 +4,10 @@ from fetcher.helpers import instantiate_aspace
 from pisces import settings
 
 
+class MissingArchivalObjectError(Exception):
+    pass
+
+
 def indicator_to_integer(indicator):
     """Converts an instance indicator to an integer.
 
@@ -119,7 +123,8 @@ class ArchivesSpaceHelper:
         """Checks whether an archival object has children using the tree/node endpoint.
         Checks the child_count attribute and if the value is greater than 0, return true, otherwise return False."""
         resp = self.aspace.client.get(uri)
-        resp.raise_for_status()
+        if resp.status_code == 404:
+            raise MissingArchivalObjectError("{} cannot be found".format(uri))
         obj = resp.json()
         resource_uri = obj['resource']['ref']
         tree_node = self.aspace.client.get('{}/tree/node?node_uri={}'.format(resource_uri, obj['uri'])).json()

--- a/merger/mergers.py
+++ b/merger/mergers.py
@@ -1,3 +1,5 @@
+from requests.exceptions import HTTPError
+
 from .helpers import (ArchivesSpaceHelper, add_group, closest_creators,
                       closest_parent_value, combine_references,
                       handle_cartographer_reference, indicator_to_integer)
@@ -27,6 +29,9 @@ class BaseMerger:
             target_object_type = self.get_target_object_type(object)
             additional_data = self.get_additional_data(object, target_object_type)
             return self.combine_data(object, additional_data), target_object_type
+        except HTTPError as e:  # 404 errors should be ignored
+            print(e)
+            pass
         except Exception as e:
             print(e)
             raise MergeError("Error merging {}: {}".format(identifier, e))

--- a/merger/mergers.py
+++ b/merger/mergers.py
@@ -1,8 +1,7 @@
-from requests.exceptions import HTTPError
-
-from .helpers import (ArchivesSpaceHelper, add_group, closest_creators,
-                      closest_parent_value, combine_references,
-                      handle_cartographer_reference, indicator_to_integer)
+from .helpers import (ArchivesSpaceHelper, MissingArchivalObjectError,
+                      add_group, closest_creators, closest_parent_value,
+                      combine_references, handle_cartographer_reference,
+                      indicator_to_integer)
 
 
 class MergeError(Exception):
@@ -29,8 +28,7 @@ class BaseMerger:
             target_object_type = self.get_target_object_type(object)
             additional_data = self.get_additional_data(object, target_object_type)
             return self.combine_data(object, additional_data), target_object_type
-        except HTTPError as e:  # 404 errors should be ignored
-            print(e)
+        except MissingArchivalObjectError:
             pass
         except Exception as e:
             print(e)


### PR DESCRIPTION
Implements exception handling to pass rather than raise further exceptions when archival objects are missing during merging.