### PR TITLE
Updates handling of agent names

### DIFF
--- a/transformer/mappings.py
+++ b/transformer/mappings.py
@@ -692,6 +692,12 @@ class SourceAgentPersonToAgent(odin.Mapping):
     from_obj = SourceAgentPerson
     to_obj = Agent
 
+    @odin.map_field(from_field="display_name", to_field="title")
+    def title(self, value):
+        first_name = value.rest_of_name if value.rest_of_name else ""
+        last_name = value.primary_name if value.primary_name else ""
+        return f'{first_name} {last_name}'.strip()
+
     @odin.map_list_field(from_field="notes", to_field="notes", to_list=True)
     def notes(self, value):
         return SourceNoteToNote.apply([v for v in value if (v.publish and v.jsonmodel_type.split("_")[-1] in NOTE_TYPE_CHOICES_TRANSFORM)])

--- a/transformer/mappings.py
+++ b/transformer/mappings.py
@@ -572,6 +572,10 @@ class SourceAgentCorporateEntityToAgent(odin.Mapping):
     from_obj = SourceAgentCorporateEntity
     to_obj = Agent
 
+    mappings = (
+        odin.define(from_field="title", to_field="authorized_name"),
+    )
+
     @odin.map_list_field(from_field="notes", to_field="notes", to_list=True)
     def notes(self, value):
         return SourceNoteToNote.apply([v for v in value if (v.publish and v.jsonmodel_type.split("_")[-1] in NOTE_TYPE_CHOICES_TRANSFORM)])
@@ -632,6 +636,10 @@ class SourceAgentFamilyToAgent(odin.Mapping):
     from_obj = SourceAgentFamily
     to_obj = Agent
 
+    mappings = (
+        odin.define(from_field="title", to_field="authorized_name"),
+    )
+
     @odin.map_list_field(from_field="notes", to_field="notes", to_list=True)
     def notes(self, value):
         return SourceNoteToNote.apply([v for v in value if (v.publish and v.jsonmodel_type.split("_")[-1] in NOTE_TYPE_CHOICES_TRANSFORM)])
@@ -691,6 +699,10 @@ class SourceAgentPersonToAgent(odin.Mapping):
     """Maps SourceAgentPerson to Agent object."""
     from_obj = SourceAgentPerson
     to_obj = Agent
+
+    mappings = (
+        odin.define(from_field="title", to_field="authorized_name"),
+    )
 
     @odin.map_field(from_field="display_name", to_field="title")
     def title(self, value):

--- a/transformer/resources/rac.py
+++ b/transformer/resources/rac.py
@@ -159,6 +159,7 @@ class Agent(BaseResource):
     Agent is a first-class entity in the RAC data model.
     """
     type = odin.StringField(default="agent")
+    authorized_name = odin.StringField()
     category = odin.StringField()
     agent_type = odin.StringField()
     description = odin.StringField(null=True)


### PR DESCRIPTION
Uses direct order for personal names, fixes #485 
Adds `authorized_name` field, fixes #486 