### PR TITLE
Target digital object publish attribute

### DIFF
--- a/fetcher/fetchers.py
+++ b/fetcher/fetchers.py
@@ -190,7 +190,7 @@ class ArchivesSpaceDataFetcher(BaseDataFetcher):
     async def get_page(self, id_list):
         params = {
             "id_set": id_list,
-            "resolve": ["ancestors", "ancestors::linked_agents", "instances::top_container", "linked_agents", "subjects"]}
+            "resolve": ["ancestors", "ancestors::linked_agents", "instances::top_container", "instances::digital_object", "linked_agents", "subjects"]}
         return clients["aspace"].client.get(self.get_endpoint(self.object_type), params=params).json()
 
 

--- a/fixtures/transformer/online_instance/multiple_instances.json
+++ b/fixtures/transformer/online_instance/multiple_instances.json
@@ -8,7 +8,12 @@
         "last_modified_by": "admin",
         "lock_version": 0,
         "system_mtime": "2020-09-21T17:01:58Z",
-        "user_mtime": "2020-09-21T17:01:58Z"
+        "user_mtime": "2020-09-21T17:01:58Z",
+        "digital_object": {
+            "_resolved": {
+                "publish": true
+            }
+        }
     },
     {
         "create_time": "2020-09-21T17:01:58Z",

--- a/fixtures/transformer/online_instance/unpublished_online_instance.json
+++ b/fixtures/transformer/online_instance/unpublished_online_instance.json
@@ -11,7 +11,7 @@
         "user_mtime": "2020-09-21T17:01:58Z",
         "digital_object": {
             "_resolved": {
-                "publish": true
+                "publish": false
             }
         }
     }

--- a/transformer/tests.py
+++ b/transformer/tests.py
@@ -225,7 +225,8 @@ class TransformerTest(TestCase):
                 ("no_online_instances.json", False, False),
                 ("online_instance.json", False, True),
                 ("no_online_instances.json", True, False),
-                ("online_instance.json", True, False)]:
+                ("online_instance.json", True, False),
+                ("unpublished_online_instance.json", False, False)]:
             with open(os.path.join("fixtures", "transformer", "online_instance", fixture), "r") as sf:
                 instances = json.load(sf)
             output = Transformer().get_online_pending(instances, online)

--- a/transformer/transformers.py
+++ b/transformer/transformers.py
@@ -60,14 +60,15 @@ class Transformer:
 
     def get_online_pending(self, instances, online):
         """
-        If digital object instances are present in the source but the transformed
+        If published digital object instances are present in the source but the transformed
         `online` field is set to False, mark the object as pending an online asset.
 
         Args:
             instances (list): source instances.
             online (bool): value of `online` field from transformed object.
         """
-        if len([v for v in instances if v["instance_type"] == "digital_object"]) and not online:
+        published_digital_instances = [v for v in instances if v["instance_type"] == "digital_object" and v.get("digital_object", {}).get("_resolved", {}).get("publish") == True]
+        if len(published_digital_instances) and not online:
             return True
         return False
 

--- a/transformer/transformers.py
+++ b/transformer/transformers.py
@@ -67,7 +67,7 @@ class Transformer:
             instances (list): source instances.
             online (bool): value of `online` field from transformed object.
         """
-        published_digital_instances = [v for v in instances if v["instance_type"] == "digital_object" and v.get("digital_object", {}).get("_resolved", {}).get("publish") == True]
+        published_digital_instances = [v for v in instances if v["instance_type"] == "digital_object" and v.get("digital_object", {}).get("_resolved", {}).get("publish")]
         if len(published_digital_instances) and not online:
             return True
         return False


### PR DESCRIPTION
Resolves digital object instances so we can check their `publish` attribute in the `online-pending` method. Updates fixtures and tests. Fixes #550 